### PR TITLE
Refactor: Adicionado salvamento de dados em uma tabela (quando o usuário solicita a remoção de dados)

### DIFF
--- a/src/api/docs/paths/cliente.ts
+++ b/src/api/docs/paths/cliente.ts
@@ -53,15 +53,44 @@ export const ClientePaths = {
                 },
             },
         },
+    },
+    "/cliente/{cpf}": {
         delete: {
             tags: ["cliente"],
             summary:
                 "Rota para remover os dados de um cliente quando solicitado",
+            requestBody: {
+                required: true,
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                nome: {
+                                    type: "string",
+                                },
+                                endereco: {
+                                    type: "string",
+                                },
+                                numero_telefone: {
+                                    type: "string",
+                                },
+                            },
+                            example: {
+                                nome: "John Doe",
+                                endereco: "Rua X, número 2",
+                                numero_telefone: "+5511123456789",
+                            },
+                            required: ["nome", "endereco", "numero_telefone"],
+                        },
+                    },
+                },
+            },
             parameters: [
                 {
                     in: "path",
-                    name: "id",
-                    description: "id do cliente a ser removido",
+                    name: "cpf",
+                    description: "cpf do cliente a ser removido",
                     required: true,
                     schema: {
                         type: "string",

--- a/src/api/routes/clienteRouter.ts
+++ b/src/api/routes/clienteRouter.ts
@@ -20,7 +20,7 @@ export function makeClienteRouter(): Router {
         clienteController.getByCpf(req, res, next),
     );
 
-    clienteRouter.delete("/:id", async (req, res, next) =>
+    clienteRouter.delete("/:cpf", async (req, res, next) =>
         clienteController.delete(req, res, next),
     );
 

--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -115,7 +115,7 @@ export class ClienteController {
             if (!cpf) {
                 return res
                     .status(StatusCode.unprocessableEntity)
-                    .json({ message: "Missing identifier id" });
+                    .json({ message: "Missing identifier cpf" });
             }
 
             if (!endereco || !numero_telefone || !nome) {

--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -109,15 +109,27 @@ export class ClienteController {
         next: NextFunction,
     ): Promise<Response> {
         try {
-            const id = req.params.id;
+            const cpf = req.params.cpf;
+            const { endereco, numero_telefone, nome } = req.body;
 
-            if (!id) {
+            if (!cpf) {
                 return res
                     .status(StatusCode.unprocessableEntity)
                     .json({ message: "Missing identifier id" });
             }
 
-            await this.clienteUseCase.delete(id);
+            if (!endereco || !numero_telefone || !nome) {
+                return res
+                    .status(StatusCode.unprocessableEntity)
+                    .json({ message: "Missing required data" });
+            }
+
+            await this.clienteUseCase.delete({
+                cpf,
+                endereco,
+                nome,
+                numero_telefone,
+            });
 
             return res
                 .status(StatusCode.ok)

--- a/src/controllers/factory.ts
+++ b/src/controllers/factory.ts
@@ -1,11 +1,15 @@
 import { ClienteController } from "./controller";
 import { ClientePostgresGateway } from "gateways/clienteGateway";
 import { PostgresDB } from "external/postgres";
-import { ClienteSchema } from "external/postgres/schemas";
+import {
+    ClienteSchema,
+    SolicitacaoRemocaoDadosSchema,
+} from "external/postgres/schemas";
 import { ClienteUseCase } from "useCases";
 import { QueueManager } from "external/queueService";
 import { serverConfig } from "config";
 import { SQSClient } from "external/queueService/client";
+import { SolicitacaoRemocaoDadosPostgresGateway } from "gateways/solicitacaoRemocaoDadosGateway";
 
 export class ClienteControllerFactory {
     public static create(): ClienteController {
@@ -13,6 +17,12 @@ export class ClienteControllerFactory {
             PostgresDB,
             ClienteSchema,
         );
+
+        const solicitacaoRemocaoDadosGateway =
+            new SolicitacaoRemocaoDadosPostgresGateway(
+                PostgresDB,
+                SolicitacaoRemocaoDadosSchema,
+            );
 
         const clienteDataOnPedidosQueueManager = new QueueManager(
             serverConfig.queues.anonimizacaoCliente,
@@ -22,6 +32,7 @@ export class ClienteControllerFactory {
         const clienteUseCase = new ClienteUseCase(
             clienteGateway,
             clienteDataOnPedidosQueueManager,
+            solicitacaoRemocaoDadosGateway,
         );
         return new ClienteController(clienteUseCase);
     }

--- a/src/entities/solicitacaoRemocaoDados.ts
+++ b/src/entities/solicitacaoRemocaoDados.ts
@@ -1,0 +1,35 @@
+import { Entity } from "../interfaces/entity.interface";
+import { AssertionConcern } from "utils/assertionConcern";
+
+interface SolicitacaoRemocaoDadosProperties
+    extends Omit<SolicitacaoRemocaoDados, "id"> {
+    id?: string;
+}
+
+export class SolicitacaoRemocaoDados implements Entity {
+    id: string;
+    nome: string;
+    endereco: string;
+    numero_telefone: string;
+
+    constructor(fields: SolicitacaoRemocaoDadosProperties) {
+        this.id = fields?.id;
+        this.nome = fields.nome;
+        this.endereco = fields.endereco;
+        this.numero_telefone = fields.numero_telefone;
+
+        this.validateEntity();
+    }
+
+    public validateEntity(): void {
+        AssertionConcern.assertArgumentNotEmpty(this.nome, "Nome is required");
+        AssertionConcern.assertArgumentNotEmpty(
+            this.numero_telefone,
+            "numero_telefone is required",
+        );
+        AssertionConcern.assertArgumentNotEmpty(
+            this.endereco,
+            "Endereco is required",
+        );
+    }
+}

--- a/src/external/postgres/migrations/0001_grey_tomas.sql
+++ b/src/external/postgres/migrations/0001_grey_tomas.sql
@@ -1,0 +1,11 @@
+CREATE SCHEMA "cliente";
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "cliente"."solicitacao_remocao_dados" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"nome" varchar(256),
+	"endereco" varchar(256),
+	"numero_telefone" varchar(256),
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "clientes" SET SCHEMA "cliente";

--- a/src/external/postgres/migrations/meta/0001_snapshot.json
+++ b/src/external/postgres/migrations/meta/0001_snapshot.json
@@ -1,0 +1,108 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "1f62b74f-866a-416d-8984-48fb6b6628c4",
+  "prevId": "21320976-629f-4031-bd4a-775e3aa9f6ce",
+  "tables": {
+    "clientes": {
+      "name": "clientes",
+      "schema": "cliente",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nome": {
+          "name": "nome",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "solicitacao_remocao_dados": {
+      "name": "solicitacao_remocao_dados",
+      "schema": "cliente",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nome": {
+          "name": "nome",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endereco": {
+          "name": "endereco",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "numero_telefone": {
+          "name": "numero_telefone",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "cliente": "cliente"
+  },
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/src/external/postgres/migrations/meta/_journal.json
+++ b/src/external/postgres/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1703340118818,
       "tag": "0000_mature_layla_miller",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1709640450470,
+      "tag": "0001_grey_tomas",
+      "breakpoints": true
     }
   ]
 }

--- a/src/external/postgres/schemas/SolicitacaoRemocaoDados.ts
+++ b/src/external/postgres/schemas/SolicitacaoRemocaoDados.ts
@@ -1,0 +1,13 @@
+import { uuid, varchar, timestamp } from "drizzle-orm/pg-core";
+import { clienteSchema } from "./Cliente";
+
+export const SolicitacaoRemocaoDadosSchema = clienteSchema.table(
+    "solicitacao_remocao_dados",
+    {
+        id: uuid("id").defaultRandom().primaryKey().notNull(),
+        nome: varchar("nome", { length: 256 }),
+        endereco: varchar("endereco", { length: 256 }),
+        numero_telefone: varchar("numero_telefone", { length: 256 }),
+        createdAt: timestamp("created_at").defaultNow().notNull(),
+    },
+);

--- a/src/external/postgres/schemas/index.ts
+++ b/src/external/postgres/schemas/index.ts
@@ -1,1 +1,2 @@
 export * from "./Cliente";
+export * from "./SolicitacaoRemocaoDados";

--- a/src/gateways/solicitacaoRemocaoDadosGateway.ts
+++ b/src/gateways/solicitacaoRemocaoDadosGateway.ts
@@ -1,0 +1,21 @@
+import { SolicitacaoRemocaoDados } from "entities/solicitacaoRemocaoDados";
+import { PostgresDB } from "external/postgres";
+import { SolicitacaoRemocaoDadosSchema } from "external/postgres/schemas";
+
+import { SolicitacaoRemocaoDadosGateway } from "interfaces/gateways/solicitacaoRemocaoDadosGateway";
+
+export class SolicitacaoRemocaoDadosPostgresGateway
+    implements SolicitacaoRemocaoDadosGateway
+{
+    constructor(
+        private readonly postgresDB: typeof PostgresDB,
+        private readonly clienteSchema: typeof SolicitacaoRemocaoDadosSchema,
+    ) {}
+
+    public async create(clienteData: SolicitacaoRemocaoDados): Promise<void> {
+        await this.postgresDB
+            .insert(this.clienteSchema)
+            .values(clienteData)
+            .returning();
+    }
+}

--- a/src/interfaces/gateways/clienteGateway.interface.ts
+++ b/src/interfaces/gateways/clienteGateway.interface.ts
@@ -1,7 +1,7 @@
 import { Cliente } from "entities/cliente";
 
 export interface ClienteGateway {
-    create(produto: Cliente): Promise<Cliente>;
+    create(cliente: Cliente): Promise<Cliente>;
     getById(id: string): Promise<Cliente | undefined>;
     getByEmail(email: string): Promise<Cliente | undefined>;
     getByCpf(cpf: string): Promise<Cliente | undefined>;

--- a/src/interfaces/gateways/pedidoGateway.interface.ts
+++ b/src/interfaces/gateways/pedidoGateway.interface.ts
@@ -1,3 +1,0 @@
-export interface PedidoGateway {
-    deleteClientesFromPedidos(id: string): Promise<void>;
-}

--- a/src/interfaces/gateways/solicitacaoRemocaoDadosGateway.ts
+++ b/src/interfaces/gateways/solicitacaoRemocaoDadosGateway.ts
@@ -1,0 +1,5 @@
+import { SolicitacaoRemocaoDados } from "entities/solicitacaoRemocaoDados";
+
+export interface SolicitacaoRemocaoDadosGateway {
+    create(cliente: SolicitacaoRemocaoDados): Promise<void>;
+}

--- a/tests/useCases/cliente/index.test.ts
+++ b/tests/useCases/cliente/index.test.ts
@@ -1,8 +1,9 @@
 import { Cliente } from "entities/cliente";
+import { SolicitacaoRemocaoDados } from "entities/solicitacaoRemocaoDados";
 import { QueueManager } from "external/queueService";
 import { SQSClient } from "external/queueService/client";
 import { ClienteGateway } from "interfaces/gateways/clienteGateway.interface";
-import { PedidoGateway } from "interfaces/gateways/pedidoGateway.interface";
+import { SolicitacaoRemocaoDadosGateway } from "interfaces/gateways/solicitacaoRemocaoDadosGateway";
 
 import { ClienteUseCase } from "useCases";
 import { ResourceNotFoundError } from "utils/errors/resourceNotFoundError";
@@ -22,6 +23,7 @@ jest.mock("external/queueService/client", () => {
 
 describe("ClienteUseCases", () => {
     let gatewayStub: ClienteGateway;
+    let solicitacaoRemocaoDadosGatewayStub: SolicitacaoRemocaoDadosGateway;
     let queueMock: QueueManager;
     let sut: ClienteUseCase;
 
@@ -70,16 +72,25 @@ describe("ClienteUseCases", () => {
             return Promise.resolve(false);
         }
     }
-    class PedidoGatewayStub implements PedidoGateway {
-        deleteClientesFromPedidos(id: string): Promise<void> {
+
+    class SolicitacaoRemocaoDadosGatewayStub
+        implements SolicitacaoRemocaoDadosGateway
+    {
+        create(cliente: SolicitacaoRemocaoDados): Promise<void> {
             return Promise.resolve();
         }
     }
 
     beforeAll(() => {
         gatewayStub = new ClienteGatewayStub();
+        solicitacaoRemocaoDadosGatewayStub =
+            new SolicitacaoRemocaoDadosGatewayStub();
         queueMock = new QueueManager("test", SQSClient);
-        sut = new ClienteUseCase(gatewayStub, queueMock);
+        sut = new ClienteUseCase(
+            gatewayStub,
+            queueMock,
+            solicitacaoRemocaoDadosGatewayStub,
+        );
     });
 
     afterAll(() => {
@@ -182,9 +193,21 @@ describe("ClienteUseCases", () => {
         describe("When the cliente requires for their data to be deleted", () => {
             it("should update clientes table and notify pedidos to also do it", async () => {
                 const deleteCliente = jest.spyOn(gatewayStub, "delete");
+                jest.spyOn(gatewayStub, "getByCpf").mockResolvedValueOnce({
+                    id: mockId,
+                    nome: "John Doe",
+                    email: Email.create(mockDTO.email),
+                    cpf: Cpf.create(mockDTO.cpf),
+                    validateEntity: () => {},
+                });
                 jest.spyOn(queueMock, "enqueueMessage").mockResolvedValueOnce();
 
-                await sut.delete(mockId);
+                await sut.delete({
+                    cpf: mockDTO.cpf,
+                    endereco: "Rua 2, 0",
+                    nome: "John Doe",
+                    numero_telefone: "123456789",
+                });
                 expect(deleteCliente).toHaveBeenCalledWith(mockId);
                 expect(queueMock.enqueueMessage).toHaveBeenCalledWith(
                     JSON.stringify({

--- a/tests/useCases/cliente/index.test.ts
+++ b/tests/useCases/cliente/index.test.ts
@@ -193,13 +193,14 @@ describe("ClienteUseCases", () => {
         describe("When the cliente requires for their data to be deleted", () => {
             it("should update clientes table and notify pedidos to also do it", async () => {
                 const deleteCliente = jest.spyOn(gatewayStub, "delete");
-                jest.spyOn(gatewayStub, "getByCpf").mockResolvedValueOnce({
-                    id: mockId,
-                    nome: "John Doe",
-                    email: Email.create(mockDTO.email),
-                    cpf: Cpf.create(mockDTO.cpf),
-                    validateEntity: () => {},
-                });
+                jest.spyOn(gatewayStub, "getByCpf").mockResolvedValueOnce(
+                    new Cliente({
+                        id: mockId,
+                        nome: "John Doe",
+                        email: Email.create(mockEmail),
+                        cpf: Cpf.create(mockCpf),
+                    }),
+                );
                 jest.spyOn(queueMock, "enqueueMessage").mockResolvedValueOnce();
 
                 await sut.delete({


### PR DESCRIPTION
# Observações
Eu mandei no canal do discord, mas [segundo essa thread](https://discord.com/channels/1065992165232214066/1208512882266869840), os professores informaram que deveríamos salvar a solicitação do usuário.

Sendo assim, criei uma tabela a parte (eles comentaram sobre logs, mas achei essa implementação mais simples) para salvarmos os dados do cliente que solicitou, além da validação se o CPF existe no banco (que estava faltando da última implementação.

Mantive nessa tabela os mesmos dados que estão na descrição do tech challenge, então se sentirem falta de algo só falem e eu altero. 